### PR TITLE
Added "re3 source lol" PR drama.

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ github/dmca
 * [pull/8122](https://github.com/github/dmca/pull/8122) ([archive.org](https://web.archive.org/web/20230129084646/https://github.com/github/dmca/pull/8122
 ), [archive.ph](https://archive.ph/l1oh6))
 * [pull/8140](https://github.com/github/dmca/pull/8140) ([archive.org](https://web.archive.org/web/20230129084629/https://github.com/github/dmca/pull/8140), [archive.ph](https://archive.ph/GrpDZ))
+* [pull/8839](https://web.archive.org/web/20210320220522/https://github.com/github/dmca/pull/8839) (archived)
 
 golang/go
 * [/issues/21956](https://github.com/golang/go/issues/21956)


### PR DESCRIPTION
After Take-Two's DMCA [request](https://github.com/github/dmca/blob/master/2021/02/2021-02-19-take-two.md), someone sends a PR to the whole code under the name "re3 source lol".

![image](https://github.com/neodrama/github-drama/assets/61117050/722589ca-dacb-4379-bd3b-f32a86f63d74)
