### PR TITLE
add archived link for deleted drama

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,8 @@ tj-actions/changed-files - Github action leaking secrets
 
 [ventoy/PXE/issues/106](https://github.com/ventoy/PXE/issues/106)
 
+[VHSgunzo/lutris-wine/issues/15 (archive)](https://archive.ph/iPHIp)
+
 [vimeo/player.js/issues/28](https://github.com/vimeo/player.js/issues/28)
 
 voat/voat - Scalability drama


### PR DESCRIPTION
The original target for `VHSgunzo/lutris-wine/issues/15` was deleted, and subsequently deleted from this repo[1], but the drama is available in public archives, so just use that.

[1]: https://github.com/neodrama/github-drama/commit/1d01b45b9d10f83512b0d57a09d496511d5e4fa4